### PR TITLE
update readme to clarify about mixpanel installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,11 @@ events like user sign ups or form submissions.
 
 ## Installation
 
+First make sure you follow the instructions for installing Mixpanel's JS
+library:
+
+https://mixpanel.com/help/reference/javascript
+
 ### With Bundler
 
 1. Add to Gemfile: `gem "mixpal"`


### PR DESCRIPTION
Coming from an outside perspective and only looking at the README it was unclear if the gem was going to do the js library include or not. 
